### PR TITLE
Fix a narrowing conversion warning.

### DIFF
--- a/firmware/application/ui_setup.cpp
+++ b/firmware/application/ui_setup.cpp
@@ -121,7 +121,7 @@ SetFrequencyCorrectionView::SetFrequencyCorrectionView(
 	} });
 
 	SetFrequencyCorrectionModel model {
-		portapack::persistent_memory::correction_ppb() / 1000
+		(int8_t) (portapack::persistent_memory::correction_ppb() / 1000)
 	};
 
 	form_init(model);


### PR DESCRIPTION
This fixes the following warning:
```
ui_setup.cpp: In constructor 'ui::SetFrequencyCorrectionView::SetFrequencyCorrectionView(ui::NavigationView&)':
ui_setup.cpp:124:50: warning: narrowing conversion of '(portapack::persistent_memory::correction_ppb() / 1000l)' from 'long int' to 'int8_t {aka signed char}' inside { } [-Wnarrowing]
   portapack::persistent_memory::correction_ppb() / 1000
```