### PR TITLE
Fix for capture hanging on exit

### DIFF
--- a/firmware/application/ui_record_view.cpp
+++ b/firmware/application/ui_record_view.cpp
@@ -173,6 +173,12 @@ void RecordView::start() {
 	update_status_display();
 }
 
+void RecordView::on_hide() {
+	stop(); // Stop current recording
+	View::on_hide();
+}
+
+
 void RecordView::stop() {
 	if( is_active() ) {
 		capture_thread.reset();

--- a/firmware/application/ui_record_view.hpp
+++ b/firmware/application/ui_record_view.hpp
@@ -59,6 +59,7 @@ public:
 
 	void start();
 	void stop();
+	void on_hide() override;
 
 	bool is_active() const;
 


### PR DESCRIPTION
Fix for capture app getting stuck when exiting without stoping the recording