### PR TITLE
Rename m4txevent::assert and m0apptxevent::assert (adding "_event")

### DIFF
--- a/firmware/application/baseband_api.cpp
+++ b/firmware/application/baseband_api.cpp
@@ -34,7 +34,7 @@ static void send_message(const Message* const message) {
 	// If message is only sent by this function via one thread, no need to check if
 	// another message is present before setting new message.
 	shared_memory.baseband_message = message;
-	creg::m0apptxevent::assert();
+	creg::m0apptxevent::assert_event();
 	while(shared_memory.baseband_message);
 }
 

--- a/firmware/baseband/stream_input.cpp
+++ b/firmware/baseband/stream_input.cpp
@@ -65,7 +65,7 @@ size_t StreamInput::write(const void* const data, const size_t length) {
 				break;
 			}
 			active_buffer = nullptr;
-			creg::m4txevent::assert();
+			creg::m4txevent::assert_event();
 		}
 	}
 

--- a/firmware/common/lpc43xx_cpp.hpp
+++ b/firmware/common/lpc43xx_cpp.hpp
@@ -69,7 +69,7 @@ inline void disable() {
 #endif
 
 #if defined(LPC43XX_M4)
-inline void assert() {
+inline void assert_event() {
 	__SEV();
 }
 #endif
@@ -93,7 +93,7 @@ inline void disable() {
 #endif
 
 #if defined(LPC43XX_M0)
-inline void assert() {
+inline void assert_event() {
 	__SEV();
 }
 #endif

--- a/firmware/common/message_queue.cpp
+++ b/firmware/common/message_queue.cpp
@@ -26,12 +26,12 @@ using namespace lpc43xx;
 
 #if defined(LPC43XX_M0)
 void MessageQueue::signal() {
-	creg::m0apptxevent::assert();
+	creg::m0apptxevent::assert_event();
 }
 #endif
 
 #if defined(LPC43XX_M4)
 void MessageQueue::signal() {
-	creg::m4txevent::assert();
+	creg::m4txevent::assert_event();
 }
 #endif


### PR DESCRIPTION
GCC 9.3.0 fix.